### PR TITLE
Fix Spotlight key capture and macOS Input Monitoring permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ pip install -r requirements.txt
 python main.py
 ```
 
-### macOS — Accessibility permission
+### macOS — Input Monitoring permission
 
-pynput requires Accessibility access to capture global key events. On first launch macOS will prompt you, or you can grant it manually:
+pynput requires **Input Monitoring** access to capture global key events. On first launch Dispatch will trigger the system permission dialog automatically. You can also grant it manually:
 
-**System Settings → Privacy & Security → Accessibility → enable Dispatch**
+**System Settings → Privacy & Security → Input Monitoring → enable Dispatch**
+
+Restart the app after enabling the permission. If Dispatch appears to be running but keys are not detected, this permission is the most likely cause.
 
 ### Linux — Wayland
 

--- a/app/input_listener.py
+++ b/app/input_listener.py
@@ -17,6 +17,12 @@ from pynput import keyboard
 
 from .key_utils import key_to_str
 
+# How long (seconds) to wait after the first captured key before delivering it.
+# Presentation remotes (e.g. Logitech Spotlight) sometimes fire a spurious
+# "forward" event immediately before the intended "back" or "spotlight" button.
+# Waiting a short window and delivering the *last* key seen avoids this.
+_CAPTURE_SETTLE_S = 0.15
+
 
 class InputListener:
     """
@@ -38,6 +44,8 @@ class InputListener:
         self._lock = threading.Lock()
         self._pressed: dict = {}            # key_str -> {time, long_fired, timer}
         self._capture_cb: Optional[Callable] = None
+        self._capture_timer: Optional[threading.Timer] = None
+        self._capture_last_key: Optional[str] = None
         self._running = False
         self._error: Optional[str] = None
 
@@ -86,16 +94,28 @@ class InputListener:
 
     def capture_next_key(self, cb: Callable[[str], None]) -> None:
         """
-        Intercept the very next key press and deliver it to *cb(key_str)*.
-        Normal action processing is bypassed for that one event.
+        Arm capture mode: deliver the last key pressed within a short settle
+        window to *cb(key_str)*.  Normal action processing is bypassed.
+
+        The settle delay (_CAPTURE_SETTLE_S) lets remotes that emit a spurious
+        key before the intended button (e.g. Logitech Spotlight) be handled
+        correctly — only the final key in the burst is delivered.
         """
         with self._lock:
+            if self._capture_timer:
+                self._capture_timer.cancel()
+                self._capture_timer = None
             self._capture_cb = cb
+            self._capture_last_key = None
 
     def cancel_capture(self) -> None:
         """Cancel any pending key-capture request."""
         with self._lock:
             self._capture_cb = None
+            self._capture_last_key = None
+            if self._capture_timer:
+                self._capture_timer.cancel()
+                self._capture_timer = None
 
     @property
     def is_running(self) -> bool:
@@ -109,31 +129,48 @@ class InputListener:
 
     def _on_press(self, key) -> None:
         key_str = key_to_str(key)
+        to_cancel = None
+        to_start = None
 
-        # Capture mode: deliver key and return without normal processing
         with self._lock:
             if self._capture_cb:
-                cb = self._capture_cb
-                self._capture_cb = None
-                try:
-                    cb(key_str)
-                except Exception:
-                    pass
-                return
+                # Settle-delay capture: each new key in the burst resets the
+                # timer and updates the candidate.  After _CAPTURE_SETTLE_S of
+                # silence the last candidate is delivered.
+                to_cancel = self._capture_timer
+                self._capture_last_key = key_str
+                cb = self._capture_cb  # keep ref; cleared inside _deliver
 
-            # Debounce key-repeat: ignore if already tracking this key
-            if key_str in self._pressed:
-                return
+                def _deliver(candidate=key_str):
+                    with self._lock:
+                        if self._capture_last_key != candidate:
+                            return  # a newer key replaced this one
+                        self._capture_cb = None
+                        self._capture_timer = None
+                        self._capture_last_key = None
+                    try:
+                        cb(candidate)
+                    except Exception:
+                        pass
 
-            # Start tracking
-            timer = threading.Timer(self._threshold, self._fire_long, args=[key_str])
-            self._pressed[key_str] = {
-                "time": time.monotonic(),
-                "long_fired": False,
-                "timer": timer,
-            }
+                to_start = threading.Timer(_CAPTURE_SETTLE_S, _deliver)
+                self._capture_timer = to_start
 
-        timer.start()
+            elif key_str in self._pressed:
+                return  # debounce key-repeat
+
+            else:
+                to_start = threading.Timer(self._threshold, self._fire_long, args=[key_str])
+                self._pressed[key_str] = {
+                    "time": time.monotonic(),
+                    "long_fired": False,
+                    "timer": to_start,
+                }
+
+        if to_cancel:
+            to_cancel.cancel()
+        if to_start:
+            to_start.start()
 
     def _on_release(self, key) -> None:
         key_str = key_to_str(key)

--- a/app/main_window.py
+++ b/app/main_window.py
@@ -66,6 +66,30 @@ def _check_input_monitoring() -> bool:
         return True  # Cannot check — avoid false warning
 
 
+def _request_input_monitoring() -> None:
+    """Trigger the macOS Input Monitoring permission dialog if not yet granted.
+
+    CGRequestListenEventAccess prompts the user and opens System Settings on
+    first call.  Subsequent calls are no-ops once permission is granted.
+    Safe to call on non-macOS or older macOS where the API is absent.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        import ctypes, ctypes.util
+        lib_path = ctypes.util.find_library("ApplicationServices")
+        if not lib_path:
+            return
+        lib = ctypes.cdll.LoadLibrary(lib_path)
+        fn = getattr(lib, "CGRequestListenEventAccess", None)
+        if fn is None:
+            return
+        fn.restype = ctypes.c_bool
+        fn()
+    except Exception:
+        pass
+
+
 class _ListenerBridge(QObject):
     """
     Bridges pynput's background thread to Qt signals.
@@ -569,12 +593,18 @@ class MainWindow(QMainWindow):
 
         lbl = QLabel(
             "⚠  Global key capture requires Input Monitoring permission.  "
-            "Open System Settings → Privacy & Security → Input Monitoring, "
-            "enable Dispatch, then restart the app."
+            "Enable Dispatch in System Settings → Privacy & Security → Input Monitoring, "
+            "then restart the app."
         )
         lbl.setObjectName("permissionBannerText")
         lbl.setWordWrap(True)
         layout.addWidget(lbl, 1)
+
+        open_btn = QPushButton("Open Settings")
+        open_btn.setObjectName("rowButton")
+        open_btn.setFixedWidth(110)
+        open_btn.clicked.connect(self._open_input_monitoring_settings)
+        layout.addWidget(open_btn)
 
         dismiss_btn = QPushButton("✕")
         dismiss_btn.setObjectName("deleteButton")
@@ -591,6 +621,13 @@ class MainWindow(QMainWindow):
 
     def _dismiss_permission_banner(self) -> None:
         self._perm_banner_frame.setVisible(False)
+
+    def _open_input_monitoring_settings(self) -> None:
+        """Open System Settings directly to the Input Monitoring pane."""
+        import subprocess
+        subprocess.Popen(
+            ["open", "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"]
+        )
 
     # ── Notification banner ───────────────────────────────────────────────────
 
@@ -1061,6 +1098,7 @@ class MainWindow(QMainWindow):
             self._listener_dot.style().polish(self._listener_dot)
             self._listener_lbl.setText("Input Monitoring permission required")
             self._show_permission_banner()
+            _request_input_monitoring()  # prompt the system permission dialog
 
     # ── Status helper ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- **Fixes #1** — Logitech Spotlight back/spotlight buttons were always captured as "forward" during Listen mode. Added a 150ms settle delay to capture: the listener now waits for the last key in a rapid burst before delivering it, so spurious forward events emitted by the Spotlight receiver are ignored in favour of the intended button.
- **Fixes #2** — Global key listening was silently broken on macOS when Input Monitoring permission was missing. Three improvements:
  - Calls `CGRequestListenEventAccess()` automatically when permission is not granted, so macOS prompts the user rather than doing nothing.
  - Adds an **Open Settings** button to the in-app permission banner that deep-links directly to Privacy & Security → Input Monitoring.
  - Corrects the README, which incorrectly said "Accessibility" permission is required — the correct permission since macOS Catalina is **Input Monitoring**.

## Test plan

- [ ] On macOS without Input Monitoring granted, launch Dispatch — system permission dialog should appear automatically
- [ ] Permission banner "Open Settings" button opens System Settings to the correct pane
- [ ] After granting permission and restarting, global key events are received
- [ ] With a Logitech Spotlight (or similar remote), click Listen and press the Back button — it should capture Back, not Forward
- [ ] Normal key capture still works (single key with no burst) with the settle delay in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)